### PR TITLE
adds button behavior in timeline

### DIFF
--- a/example/buttons.md
+++ b/example/buttons.md
@@ -1,0 +1,9 @@
+# Adding buttons
+Use [.buttonBehavior( )](https://github.com/d3plus/d3plus-timeline#Timeline.buttonBehavior) to modify style of the timeline. Accepted values are "buttons" and "ticks". 
+
+```js
+new d3plus.Timeline()
+  .domain([2001, 2010])
+  .buttonBehavior("buttons")
+  .render();
+```

--- a/example/buttons.md
+++ b/example/buttons.md
@@ -1,9 +1,0 @@
-# Adding buttons
-Use [.buttonBehavior( )](https://github.com/d3plus/d3plus-timeline#Timeline.buttonBehavior) to modify style of the timeline. Accepted values are "buttons" and "ticks". 
-
-```js
-new d3plus.Timeline()
-  .domain([2001, 2010])
-  .buttonBehavior("ticks")
-  .render();
-```

--- a/example/buttons.md
+++ b/example/buttons.md
@@ -4,6 +4,6 @@ Use [.buttonBehavior( )](https://github.com/d3plus/d3plus-timeline#Timeline.butt
 ```js
 new d3plus.Timeline()
   .domain([2001, 2010])
-  .buttonBehavior("buttons")
+  .buttonBehavior("ticks")
   .render();
 ```

--- a/example/change-style.md
+++ b/example/change-style.md
@@ -11,6 +11,7 @@ new d3plus.Timeline()
     fill: "red",
     stroke: "black"
   })
+  .buttonBehavior("ticks")
   .shapeConfig({
     height: 6,
     fill: "red",
@@ -19,3 +20,5 @@ new d3plus.Timeline()
   })
   .render();
 ```
+
+*If you want to change the style of shapes, you must to set `.buttonBehavior("ticks")` for correct behavior in Timeline. Currently "buttons" method doesn't support with `shapeConfig`.

--- a/example/change-style.md
+++ b/example/change-style.md
@@ -20,5 +20,3 @@ new d3plus.Timeline()
   })
   .render();
 ```
-
-*If you want to change the style of shapes, you must to set `.buttonBehavior("ticks")` for correct behavior in Timeline. Currently "buttons" method doesn't support with `shapeConfig`.

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -223,10 +223,8 @@ export default class Timeline extends Axis {
     const {height, y} = this._position;
     let ticksWidth = 0;
 
-    if (this._ticks && !this._labels) {
-      this._domain = [min(this._ticks), max(this._ticks)];
-      this.labels(this._ticks);
-    }
+    if (this._ticks && !this._labels) this.labels(this._ticks);
+
 
     if (this._buttonBehavior === "auto") {
       let ticks = this._ticks ? this._ticks.map(date) : this._domain.map(date);

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -69,10 +69,10 @@ export default class Timeline extends Axis {
 
     if (event.sourceEvent && event.sourceEvent.offsetX && event.selection !== null && (!this._brushing || this._snapping)) {
 
-      const margin = 0.5 * (this._ticksWidth / this._availableTicks.length - 2 * this._handleSize - 0.2),
+      const buttonDomain = 0.5 * (this._ticksWidth / this._availableTicks.length - 2 * this._handleSize - 0.2),
             selection =  this._buttonBehaviorCurrent === "ticks" || event.selection[1] === event.selection[0]
-              ? event.selection : [event.selection[0] + margin, event.selection[1] - margin].sort((a, b) => a - b);
-      
+              ? event.selection : [event.selection[0] + buttonDomain, event.selection[1] - buttonDomain].sort((a, b) => a - b);
+
       const domain = (this._brushing ? selection
         : [event.selection[0], event.selection[0]])
         .map(this._d3Scale.invert)

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -24,15 +24,20 @@ export default class Timeline extends Axis {
 
     super();
 
+    this._barConfig = {
+      strokeWidth: 0
+    };
     this._brushing = true;
     this._brushFilter = () => !event.button && event.detail < 2;
     this._domain = [2001, 2010];
     this._gridSize = 0;
     this._handleConfig = {
-      fill: "#444"
+      height: 30,
+      fill: true ? "#444" : "#444",
+      opacity: true ? 0.25 : 1
     };
-    this._handleSize = 6;
-    this._height = 100;
+    this._handleSize = true ? this._width / 6 : 6;
+    this._height = true ? 60 : 100;
     this._on = {};
     this.orient("bottom");
     this._scale = "time";
@@ -42,12 +47,13 @@ export default class Timeline extends Axis {
     };
     this._shape = "Rect";
     this._shapeConfig = Object.assign({}, this._shapeConfig, {
-      fill: d => true ? "pink" : d,
-      labelBounds: {x: -20, y: -5, width: 40, height: 15},
-      height: d => true ? 40 : d.tick ? 10 : 0,
-      width: d => true ? this._space - 5 : (d.tick ? this._domain.map(t => date(t).getTime()).includes(d.id) ? 2 : 1 : 0)
+      fill: d => true ? "#EEE" : d,
+      labelBounds: {x: -20, y: -5, width: 40, height: 30},
+      height: d => true ? 30 : d.tick ? 10 : 0,
+      width: d => true ? this._width / this._availableTicks.length : (d.tick ? this._domain.map(t => date(t).getTime()).includes(d.id) ? 2 : 1 : 0)
     });
     this._snapping = true;
+    this._padding = 0;
 
   }
 
@@ -188,6 +194,13 @@ export default class Timeline extends Axis {
     this._brushGroup.selectAll(".handle")
       .call(attrize, this._handleConfig)
       .attr("height", timelineHeight + this._handleSize);
+    
+    if (true) {
+      this._brushGroup.selectAll(".handle")
+      .call(attrize, this._handleConfig)
+      .attr("height", 30)
+      .attr("y", 7.5);
+    }
 
   }
 
@@ -205,7 +218,8 @@ export default class Timeline extends Axis {
 
     const offset = this._outerBounds[y],
           range = this._d3Scale.range();
-
+console.log(offset)
+console.log(range)
     const brush = this._brush = brushX()
       .extent([[range[0], offset], [range[1], offset + this._outerBounds[height]]])
       .filter(this._brushFilter)
@@ -233,6 +247,8 @@ export default class Timeline extends Axis {
 
     this._outerBounds.y -= this._handleSize / 2;
     this._outerBounds.height += this._handleSize / 2;
+
+    console.log(this)
 
     return this;
 

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -2,7 +2,7 @@
     @external Axis
     @see https://github.com/d3plus/d3plus-axis#Axis
 */
-import {max} from "d3-array";
+import {max, min} from "d3-array";
 import {brushX} from "d3-brush";
 import {scaleTime} from "d3-scale";
 import {event} from "d3-selection";
@@ -225,6 +225,11 @@ export default class Timeline extends Axis {
     const {height, y} = this._position;
     let ticksWidth = 0;
 
+    if (this._ticks) {
+      this._domain = [min(this._ticks), max(this._ticks)];
+      this.labels(this._ticks);
+    }
+
     if (this._buttonBehavior === "auto") {
       const ticks = this._ticks ? this._ticks.map(date) : this._domain.map(date);
       const d3Scale = scaleTime().domain(ticks).range([0, this._width]), 
@@ -245,7 +250,7 @@ export default class Timeline extends Axis {
           ? Math.ceil(max(res.lines.map(line => textWidth(line, {"font-family": f, "font-size": s})))) + s / 4
           : 0;
         if (width % 2) width++;
-  
+        console.log(res)
         return sum + width + 2 * this._buttonPadding;
       }, 0);
     }
@@ -253,6 +258,8 @@ export default class Timeline extends Axis {
     this._buttonBehaviorCurrent = this._buttonBehavior === "auto" ? ticksWidth < this._width ? (this._width = ticksWidth, "buttons") : "ticks" : this._buttonBehavior;
 
     super.render(callback);
+    
+    console.log(this)
 
     const offset = this._outerBounds[y],
           range = this._d3Scale.range();

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -223,7 +223,7 @@ export default class Timeline extends Axis {
     const {height, y} = this._position;
     let ticksWidth = 0;
 
-    if (this._ticks) {
+    if (this._ticks && !this._labels) {
       this._domain = [min(this._ticks), max(this._ticks)];
       this.labels(this._ticks);
     }
@@ -323,6 +323,25 @@ function() {
     return arguments.length ? (this._buttonBehavior = _, this) : this._buttonBehavior;
   }
 
+  /**
+        @memberof Timeline
+        @desc If *value* is specified, sets the button height and returns the current class instance. If *value* is not specified, returns the current button height.
+        @param {Number} [*value* = 30]
+        @chainable
+    */
+  buttonHeight(_) {
+    return arguments.length ? (this._buttonHeight = _, this) : this._buttonHeight;
+  }
+
+  /**
+        @memberof Timeline
+        @desc If *value* is specified, sets the button padding and returns the current class instance. If *value* is not specified, returns the current button padding.
+        @param {Number} [*value* = 10]
+        @chainable
+    */
+  buttonPadding(_) {
+    return arguments.length ? (this._buttonPadding = _, this) : this._buttonPadding;
+  }
 
   /**
       @memberof Timeline

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -69,9 +69,10 @@ export default class Timeline extends Axis {
 
     if (event.sourceEvent && event.sourceEvent.offsetX && event.selection !== null && (!this._brushing || this._snapping)) {
 
-      const buttonDomain = 0.5 * (this._ticksWidth / this._availableTicks.length - 2 * this._handleSize - 0.2),
-            selection =  this._buttonBehaviorCurrent === "ticks" || event.selection[1] === event.selection[0]
-              ? event.selection : [event.selection[0] + buttonDomain, event.selection[1] - buttonDomain].sort((a, b) => a - b);
+      const buttonDomain = 0.5 * (this._ticksWidth / this._availableTicks.length - this._handleSize + 0.2),
+            selection =  this._buttonBehaviorCurrent === "ticks" || event.selection[1] === event.selection[0] || buttonDomain === Math.round((event.selection[1] - event.selection[0]) * 10) / 10
+              ? event.selection 
+              : [event.selection[0] + buttonDomain, event.selection[1] - buttonDomain].sort((a, b) => a - b);
 
       const domain = (this._brushing ? selection
         : this._buttonBehaviorCurrent === "buttons" 

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -222,8 +222,6 @@ export default class Timeline extends Axis {
   */
   render(callback) {
     const {height, y} = this._position;
-    const defaultWidth = this._width;
-    let ticksWidth = 0;
 
     if (this._buttonBehavior === "auto") {
       let ticks = this._ticks ? this._ticks.map(date) : this._domain.map(date);

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -287,8 +287,9 @@ export default class Timeline extends Axis {
       .call(brush.move, selection);
       
     if (this._buttonBehaviorCurrent === "buttons") {
-      elem(`g#d3plus-Axis-${this._uuid}`).node().parentNode.setAttribute("width", defaultWidth);
       const marginLeft = defaultWidth - this._width;
+      elem(`g#d3plus-Axis-${this._uuid}`).node().parentNode.setAttribute("width", defaultWidth);
+
       if (this._align === "middle") this._group.attr("transform", `translate(${marginLeft / 2}, 0)`);
       else if (this._align === "end") this._group.attr("transform", `translate(${marginLeft}, 0)`);
     }

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -33,11 +33,11 @@ export default class Timeline extends Axis {
     this._gridSize = 0;
     this._handleConfig = {
       height: 30,
-      fill: true ? "#444" : "#444",
-      opacity: true ? 0.25 : 1
+      fill: true ? "#222" : "#444",
+      opacity: true ? 1 : 1
     };
-    this._handleSize = true ? this._width / 6 : 6;
-    this._height = true ? 60 : 100;
+    this._handleSize = 6;
+    this._height = true ? 45 : 100;
     this._on = {};
     this.orient("bottom");
     this._scale = "time";
@@ -50,10 +50,10 @@ export default class Timeline extends Axis {
       fill: d => true ? "#EEE" : d,
       labelBounds: {x: -20, y: -5, width: 40, height: 30},
       height: d => true ? 30 : d.tick ? 10 : 0,
-      width: d => true ? this._width / this._availableTicks.length : (d.tick ? this._domain.map(t => date(t).getTime()).includes(d.id) ? 2 : 1 : 0)
+      width: d => true ? this._width / this._availableTicks.length : (d.tick ? this._domain.map(t => date(t).getTime()).includes(d.id) ? 2 : 1 : 0),
+      y: 45 - 30 + 5 + 2
     });
     this._snapping = true;
-    this._padding = 0;
 
   }
 
@@ -196,6 +196,13 @@ export default class Timeline extends Axis {
       .attr("height", timelineHeight + this._handleSize);
     
     if (true) {
+      
+
+      this._brushGroup.selectAll(".selection")
+      .call(attrize, this._selectionConfig)
+      .attr("height", timelineHeight)
+      .attr("y", 7.5);
+    
       this._brushGroup.selectAll(".handle")
       .call(attrize, this._handleConfig)
       .attr("height", 30)

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -26,15 +26,16 @@ export default class Timeline extends Axis {
 
     this._brushing = true;
     this._brushFilter = () => !event.button && event.detail < 2;
-    this._buttonBehavior = "ticks";
+    this._buttonBehavior = "buttons";
     this._buttonBehaviorCurrent =  this._buttonBehavior !== "auto" ? this._buttonBehavior : "buttons";
+    this._buttonHeight = 30;
     this._domain = [2001, 2010];
     this._gridSize = 0;
     this._handleConfig = {
       fill: this._buttonBehaviorCurrent === "buttons" ? "#222" : "#444"
     };
     this._handleSize = 6;
-    this._height = this._buttonBehaviorCurrent === "buttons" ? 45 : 100;
+    this._height = 100;
     this._on = {};
     this.orient("bottom");
     this._scale = "time";
@@ -45,11 +46,12 @@ export default class Timeline extends Axis {
     this._shape = "Rect";
     this._shapeConfig = Object.assign({}, this._shapeConfig, {
       fill: this._buttonBehaviorCurrent === "buttons" ? "#EEE" : "#444",
-      height: d => this._buttonBehaviorCurrent === "buttons" ? 30 : d.tick ? 10 : 0,
+      height: d => this._buttonBehaviorCurrent === "buttons" ? this._buttonHeight : d.tick ? 10 : 0,
       width: d => this._buttonBehaviorCurrent === "buttons" ? this._width / this._availableTicks.length : d.tick ? this._domain.map(t => date(t).getTime()).includes(d.id) ? 2 : 1 : 0
     }, this._buttonBehaviorCurrent === "buttons" ? {
-      labelBounds: {x: -20, y: -5, width: 40, height: 30},
-      y: this._height - 30 + 5 + 2
+      labelBounds: {x: -20, y: -5, width: 40, height: this._buttonHeight},
+      y: this._height / 2
+      //y: this._height - 30 + 5 + 2
     } : {});
     this._snapping = true;
 
@@ -58,8 +60,6 @@ export default class Timeline extends Axis {
         strokeWidth: 0
       };
     }
-
-    console.log(this._buttonBehaviorCurrent)
 
   }
 
@@ -229,15 +229,17 @@ export default class Timeline extends Axis {
     
     if (buttons) {
 
+      const yTransform = this._height / 2 - this._buttonHeight / 2;
+
       this._brushGroup.selectAll(".selection")
       .call(attrize, this._selectionConfig)
       .attr("height", timelineHeight)
-      .attr("y", 7.5);
+      .attr("y", yTransform);
 
       this._brushGroup.selectAll(".handle")
       .call(attrize, this._handleConfig)
-      .attr("height", 30)
-      .attr("y", 7.5);
+      .attr("height", this._buttonHeight)
+      .attr("y", yTransform);
 
     }
 
@@ -252,8 +254,6 @@ export default class Timeline extends Axis {
   render(callback) {
 
     super.render(callback);
-
-    this._buttonBehaviorCurrent = this._buttonBehavior === "buttons" || this._buttonBehavior === "auto" && this._availableTicks === this._visibleTicks ? "buttons" : "ticks";
 
     const {height, y} = this._position;
 
@@ -292,6 +292,8 @@ export default class Timeline extends Axis {
     this._brushGroup = elem("g.brushGroup", {parent: this._group});
     this._brushGroup.call(brush).transition(this._transition)
       .call(brush.move, selection);
+
+    this._buttonBehaviorCurrent = this._buttonBehavior === "buttons" || this._buttonBehavior === "auto" && this._availableTicks === this._visibleTicks ? "buttons" : "ticks";
 
     this._outerBounds.y -= this._handleSize / 2;
     this._outerBounds.height += this._handleSize / 2;

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -51,7 +51,6 @@ export default class Timeline extends Axis {
     this._shape = "Rect";
     this._shapeConfig = Object.assign({}, this._shapeConfig, {
       labelBounds: d => this._buttonBehaviorCurrent === "buttons" ? {x: d.labelBounds.x, y: -5, width: d.labelBounds.width, height: this._buttonHeight} : d.labelBounds,
-      labelConfig: Object.assign({}, this._shapeConfig.labelConfig, {rotate: 0}),
       fill: () => this._buttonBehaviorCurrent === "buttons" ? "#EEE" : "#444",
       height: d => this._buttonBehaviorCurrent === "buttons" ? this._buttonHeight : d.tick ? 10 : 0,
       width: d => this._buttonBehaviorCurrent === "buttons" ? this._width / this._availableTicks.length : d.tick ? this._domain.map(t => date(t).getTime()).includes(d.id) ? 2 : 1 : 0,
@@ -231,12 +230,13 @@ export default class Timeline extends Axis {
     }
 
     if (this._buttonBehavior === "auto") {
-      const ticks = this._ticks ? this._ticks.map(date) : this._domain.map(date);
+      let ticks = this._ticks ? this._ticks.map(date) : this._domain.map(date);
       const d3Scale = scaleTime().domain(ticks).range([0, this._width]), 
             tickFormat = d3Scale.tickFormat();
 
+      ticks = this._ticks ? ticks : d3Scale.ticks();
       // Measures size of ticks
-      ticksWidth = d3Scale.ticks().reduce((sum, d, i) => {
+      ticksWidth = ticks.reduce((sum, d, i) => {
         const f = this._shapeConfig.labelConfig.fontFamily(d, i),
               s = this._shapeConfig.labelConfig.fontSize(d, i);
   

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -258,8 +258,7 @@ export default class Timeline extends Axis {
     }
 
     super.render(callback);
-    this._margin.left = 400;
-    this._margin.right = 400;
+
     const offset = this._outerBounds[y],
           range = this._d3Scale.range();
 

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -250,7 +250,6 @@ export default class Timeline extends Axis {
           ? Math.ceil(max(res.lines.map(line => textWidth(line, {"font-family": f, "font-size": s})))) + s / 4
           : 0;
         if (width % 2) width++;
-        console.log(res)
         return sum + width + 2 * this._buttonPadding;
       }, 0);
     }
@@ -258,8 +257,6 @@ export default class Timeline extends Axis {
     this._buttonBehaviorCurrent = this._buttonBehavior === "auto" ? ticksWidth < this._width ? (this._width = ticksWidth, "buttons") : "ticks" : this._buttonBehavior;
 
     super.render(callback);
-    
-    console.log(this)
 
     const offset = this._outerBounds[y],
           range = this._d3Scale.range();

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -32,7 +32,7 @@ export default class Timeline extends Axis {
     this._brushFilter = () => !event.button && event.detail < 2;
     this._buttonBehavior = "auto";
     this._buttonHeight = 30;
-    this._buttonPadding = 10;
+    this._buttonPadding = 12;
     this._domain = [2001, 2010];
     this._gridSize = 0;
     this._handleConfig = {
@@ -75,6 +75,7 @@ export default class Timeline extends Axis {
         .map(Number);
 
       const ticks = this._availableTicks.map(Number);
+
       domain[0] = date(closest(domain[0], ticks));
       domain[1] = date(closest(domain[1], ticks));
 
@@ -188,7 +189,7 @@ export default class Timeline extends Axis {
       const yTransform = this._height / 2 - this._buttonHeight / 2;
 
       brushHandle.attr("y", yTransform);
-      brushOverlay.attr("x", 0).attr("width", this._ticksWidth);
+      brushOverlay.attr("x", this._marginLeft).attr("width", this._ticksWidth);
       brushSelection.attr("y", yTransform);
     }
 
@@ -234,12 +235,14 @@ export default class Timeline extends Axis {
         const f = this._shapeConfig.labelConfig.fontFamily(d, i),
               s = this._shapeConfig.labelConfig.fontSize(d, i);
   
+              
         const wrap = textWrap()
           .fontFamily(f)
           .fontSize(s)
           .lineHeight(this._shapeConfig.lineHeight ? this._shapeConfig.lineHeight(d, i) : undefined);
   
         const res = wrap(tickFormat(d));
+
         let width = res.lines.length
           ? Math.ceil(max(res.lines.map(line => textWidth(line, {"font-family": f, "font-size": s})))) + s / 4
           : 0;
@@ -255,11 +258,25 @@ export default class Timeline extends Axis {
       this.labels(this._ticks);
     }
     if (this._ticksWidth && this._buttonBehaviorCurrent === "buttons") {
-      this._range = [undefined, this._ticksWidth - 2 * this._buttonPadding]; 
+      let ticks = this._ticks ? this._ticks.map(date) : this._domain.map(date);
+      const d3Scale = scaleTime().domain(ticks).range([0, this._ticksWidth]);
+
+      ticks = this._ticks ? ticks : d3Scale.ticks();
+
+      const buttonMargin = 0.5 * this._ticksWidth / ticks.length;
+      this._marginLeft = this._align === "start" 
+        ? undefined : this._align === "middle" 
+          ? (this._width - this._ticksWidth) / 2 : this._width - this._ticksWidth;
+
+      const marginRight = this._align === "end"
+        ? undefined : this._align === "middle"
+          ? (this._width + this._ticksWidth) / 2 - buttonMargin : this._ticksWidth - buttonMargin;
+
+      this._range = [this._align === "start" ? undefined : this._marginLeft + buttonMargin, marginRight]; 
     }
     
     super.render(callback);
-    
+
     const offset = this._outerBounds[y],
           range = this._d3Scale.range();
 

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -223,7 +223,10 @@ export default class Timeline extends Axis {
     const {height, y} = this._position;
     let ticksWidth = 0;
 
-    if (this._ticks && !this._labels) this.labels(this._ticks);
+    if (this._ticks && !this._labels) {
+      this._domain = [min(this._ticks), max(this._ticks)];
+      this.labels(this._ticks);
+    }
 
     if (this._buttonBehavior === "auto") {
       let ticks = this._ticks ? this._ticks.map(date) : this._domain.map(date);

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -6,7 +6,6 @@ import {max, min} from "d3-array";
 import {brushX} from "d3-brush";
 import {scaleTime} from "d3-scale";
 import {event} from "d3-selection";
-import {timeYear} from "d3-time";
 
 import {Axis, date} from "d3plus-axis";
 import {attrize, closest, elem} from "d3plus-common";

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -24,16 +24,13 @@ export default class Timeline extends Axis {
 
     super();
 
-    this._barConfig = {
-      strokeWidth: 0
-    };
     this._brushing = true;
     this._brushFilter = () => !event.button && event.detail < 2;
     this._buttons = true;
     this._domain = [2001, 2010];
     this._gridSize = 0;
     this._handleConfig = {
-      fill: true ? "#222" : "#444"
+      fill: this._buttons ? "#222" : "#444"
     };
     this._handleSize = 6;
     this._height = this._buttons ? 45 : 100;
@@ -46,13 +43,20 @@ export default class Timeline extends Axis {
     };
     this._shape = "Rect";
     this._shapeConfig = Object.assign({}, this._shapeConfig, {
-      fill: this._buttons ? "#EEE" : "#000",
-      labelBounds: {x: -20, y: -5, width: 40, height: 30},
+      fill: this._buttons ? "#EEE" : "#444",
       height: d => this._buttons ? 30 : d.tick ? 10 : 0,
-      width: d => this._buttons ? this._width / this._availableTicks.length : (d.tick ? this._domain.map(t => date(t).getTime()).includes(d.id) ? 2 : 1 : 0),
-      y: 45 - 30 + 5 + 2
+      width: d => this._buttons ? this._width / this._availableTicks.length : (d.tick ? this._domain.map(t => date(t).getTime()).includes(d.id) ? 2 : 1 : 0)
     });
     this._snapping = true;
+
+    if (this._buttons) {
+      this._barConfig = {
+        strokeWidth: 0
+      };
+      this._shapeConfig.height = 30;
+      this._shapeConfig.labelBounds = {x: -20, y: -5, width: 40, height: 30};
+      this._shapeConfig.y = this._height - 30 + 5 + 2;
+    }
 
   }
 
@@ -81,8 +85,9 @@ export default class Timeline extends Axis {
       const pixelDomain = domain.map(this._d3Scale);
 
       if (this._buttons) {
-        pixelDomain[0] -= 0.5 * this._width / this._availableTicks.length - this._handleSize / 2;
-        pixelDomain[1] += 0.5 * this._width / this._availableTicks.length - this._handleSize / 2;
+        const desv = 0.5 * (this._width / this._availableTicks.length - this._handleSize);
+        pixelDomain[0] -= desv;
+        pixelDomain[1] += desv;
       }
 
       if (single) {
@@ -129,8 +134,9 @@ export default class Timeline extends Axis {
       } 
 
       if (this._buttons) {
-        pixelDomain[0] -= 0.5 * this._width / this._availableTicks.length - this._handleSize / 2;
-        pixelDomain[1] += 0.5 * this._width / this._availableTicks.length - this._handleSize / 2;
+        const desv = 0.5 * (this._width / this._availableTicks.length - this._handleSize);
+        pixelDomain[0] -= desv;
+        pixelDomain[1] += desv;
       }
 
       this._brushGroup.transition(this._transition).call(this._brush.move, pixelDomain);
@@ -171,8 +177,9 @@ export default class Timeline extends Axis {
       }
 
       if (this._buttons) {
-        pixelDomain[0] -= 0.5 * this._width / this._availableTicks.length - this._handleSize / 2;
-        pixelDomain[1] += 0.5 * this._width / this._availableTicks.length - this._handleSize / 2;
+        const desv = 0.5 * (this._width / this._availableTicks.length - this._handleSize);
+        pixelDomain[0] -= desv;
+        pixelDomain[1] += desv;
       }
 
       this._brushGroup.call(this._brush.move, pixelDomain);
@@ -262,8 +269,9 @@ export default class Timeline extends Axis {
     }
 
     if (this._buttons) {
-      selection[0] -= 0.5 * this._width / this._availableTicks.length - this._handleSize / 2;
-      selection[1] += 0.5 * this._width / this._availableTicks.length - this._handleSize / 2;
+      const desv = 0.5 * (this._width / this._availableTicks.length - this._handleSize);
+      selection[0] -= desv;
+      selection[1] += desv;
     }
 
     this._brushGroup = elem("g.brushGroup", {parent: this._group});
@@ -300,6 +308,17 @@ function() {
   brushFilter(_) {
     return arguments.length ? (this._brushFilter = _, this) : this._brushFilter;
   }
+
+  /**
+      @memberof Timeline
+      @desc If *value* is specified, toggles the buttons value and returns the current class instance. If *value* is not specified, returns the current button value.
+      @param {Boolean} [*value* = false]
+      @chainable
+  */
+  buttons(_) {
+    return arguments.length ? (this._buttons = _, this) : this._buttons;
+  }
+
 
   /**
       @memberof Timeline

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -312,7 +312,7 @@ function() {
   /**
       @memberof Timeline
       @desc If *value* is specified, toggles the buttons value and returns the current class instance. If *value* is not specified, returns the current button value.
-      @param {String} [*value* = false]
+      @param {String} [*value* = "ticks"]
       @chainable
   */
   buttonBehavior(_) {

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -7,7 +7,7 @@ import {brushX} from "d3-brush";
 import {event} from "d3-selection";
 
 import {Axis, date} from "d3plus-axis";
-import {attrize, closest, elem, accessor, constant} from "d3plus-common";
+import {attrize, closest, elem} from "d3plus-common";
 
 /**
     @class Timeline

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -42,8 +42,10 @@ export default class Timeline extends Axis {
     };
     this._shape = "Rect";
     this._shapeConfig = Object.assign({}, this._shapeConfig, {
-      height: d => d.tick ? 10 : 0,
-      width: d => d.tick ? this._domain.map(t => date(t).getTime()).includes(d.id) ? 2 : 1 : 0
+      fill: d => true ? "pink" : d,
+      labelBounds: {x: -20, y: -5, width: 40, height: 15},
+      height: d => true ? 40 : d.tick ? 10 : 0,
+      width: d => true ? this._space - 5 : (d.tick ? this._domain.map(t => date(t).getTime()).includes(d.id) ? 2 : 1 : 0)
     });
     this._snapping = true;
 

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -74,7 +74,8 @@ export default class Timeline extends Axis {
               ? event.selection : [event.selection[0] + buttonDomain, event.selection[1] - buttonDomain].sort((a, b) => a - b);
 
       const domain = (this._brushing ? selection
-        : [event.selection[0], event.selection[0]])
+        : this._buttonBehaviorCurrent === "buttons" 
+          ? [event.sourceEvent.offsetX, event.sourceEvent.offsetX] : [event.selection[0], event.selection[0]])
         .map(this._d3Scale.invert)
         .map(Number);
 
@@ -228,7 +229,7 @@ export default class Timeline extends Axis {
   render(callback) {
     const {height, y} = this._position;
 
-    if (this._buttonBehavior === "auto") {
+    if (this._buttonBehavior !== "ticks") {
       let ticks = this._ticks ? this._ticks.map(date) : this._domain.map(date);
       const d3Scale = scaleTime().domain(ticks).range([0, this._width]), 
             tickFormat = d3Scale.tickFormat();
@@ -279,7 +280,11 @@ export default class Timeline extends Axis {
 
       this._range = [this._align === "start" ? undefined : this._marginLeft + buttonMargin, marginRight]; 
     }
-    
+
+    if (this._buttonBehaviorCurrent === "buttons" && !this._brushing) {
+      this._handleSize = 0;
+    }
+
     super.render(callback);
 
     const offset = this._outerBounds[y],

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -4,8 +4,8 @@
 */
 import {max} from "d3-array";
 import {brushX} from "d3-brush";
-import {event} from "d3-selection";
 import {scaleTime} from "d3-scale";
+import {event} from "d3-selection";
 import {Axis, date} from "d3plus-axis";
 import {attrize, closest, elem} from "d3plus-common";
 import {textWidth, textWrap} from "d3plus-text";
@@ -247,7 +247,6 @@ export default class Timeline extends Axis {
     });
 
     const ticksWidth = textData.reduce((d, i) => d + i.width, 0);
-    console.log(ticksWidth)
 
     this._buttonBehaviorCurrent = this._buttonBehavior === "auto" ? ticksWidth < this._width ? "buttons" : "ticks" : this._buttonBehavior;
 

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -257,20 +257,21 @@ export default class Timeline extends Axis {
       if (this._buttonBehaviorCurrent === "ticks") this._domain = [min(this._ticks), max(this._ticks)];
       this.labels(this._ticks);
     }
+
     if (this._ticksWidth && this._buttonBehaviorCurrent === "buttons") {
       let ticks = this._ticks ? this._ticks.map(date) : this._domain.map(date);
       const d3Scale = scaleTime().domain(ticks).range([0, this._ticksWidth]);
-
       ticks = this._ticks ? ticks : d3Scale.ticks();
 
       const buttonMargin = 0.5 * this._ticksWidth / ticks.length;
-      this._marginLeft = this._align === "start" 
-        ? undefined : this._align === "middle" 
-          ? (this._width - this._ticksWidth) / 2 : this._width - this._ticksWidth;
 
-      const marginRight = this._align === "end"
-        ? undefined : this._align === "middle"
-          ? (this._width + this._ticksWidth) / 2 - buttonMargin : this._ticksWidth - buttonMargin;
+      this._marginLeft = this._align === "middle" 
+        ? (this._width - this._ticksWidth) / 2 : this._align === "end" 
+          ? this._width - this._ticksWidth : 0;
+
+      const marginRight = this._align === "middle"
+        ? (this._width + this._ticksWidth) / 2 - buttonMargin : this._align === "start" 
+          ? this._ticksWidth - buttonMargin : undefined;
 
       this._range = [this._align === "start" ? undefined : this._marginLeft + buttonMargin, marginRight]; 
     }

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -69,7 +69,11 @@ export default class Timeline extends Axis {
 
     if (event.sourceEvent && event.sourceEvent.offsetX && event.selection !== null && (!this._brushing || this._snapping)) {
 
-      const domain = (this._brushing ? event.selection
+      const margin = 0.5 * (this._ticksWidth / this._availableTicks.length - 2 * this._handleSize - 0.2),
+            selection =  this._buttonBehaviorCurrent === "ticks" || event.selection[1] === event.selection[0]
+              ? event.selection : [event.selection[0] + margin, event.selection[1] - margin].sort((a, b) => a - b);
+      
+      const domain = (this._brushing ? selection
         : [event.selection[0], event.selection[0]])
         .map(this._d3Scale.invert)
         .map(Number);

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -236,7 +236,7 @@ export default class Timeline extends Axis {
             tickFormat = d3Scale.tickFormat();
 
       // Measures size of ticks
-      ticksWidth = d3Scale.ticks(timeYear).reduce((sum, d, i) => {
+      ticksWidth = d3Scale.ticks().reduce((sum, d, i) => {
         const f = this._shapeConfig.labelConfig.fontFamily(d, i),
               s = this._shapeConfig.labelConfig.fontSize(d, i);
   

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -29,15 +29,14 @@ export default class Timeline extends Axis {
     };
     this._brushing = true;
     this._brushFilter = () => !event.button && event.detail < 2;
+    this._buttons = true;
     this._domain = [2001, 2010];
     this._gridSize = 0;
     this._handleConfig = {
-      height: 30,
-      fill: true ? "#222" : "#444",
-      opacity: true ? 1 : 1
+      fill: true ? "#222" : "#444"
     };
     this._handleSize = 6;
-    this._height = true ? 45 : 100;
+    this._height = this._buttons ? 45 : 100;
     this._on = {};
     this.orient("bottom");
     this._scale = "time";
@@ -47,10 +46,10 @@ export default class Timeline extends Axis {
     };
     this._shape = "Rect";
     this._shapeConfig = Object.assign({}, this._shapeConfig, {
-      fill: d => true ? "#EEE" : d,
+      fill: this._buttons ? "#EEE" : "#000",
       labelBounds: {x: -20, y: -5, width: 40, height: 30},
-      height: d => true ? 30 : d.tick ? 10 : 0,
-      width: d => true ? this._width / this._availableTicks.length : (d.tick ? this._domain.map(t => date(t).getTime()).includes(d.id) ? 2 : 1 : 0),
+      height: d => this._buttons ? 30 : d.tick ? 10 : 0,
+      width: d => this._buttons ? this._width / this._availableTicks.length : (d.tick ? this._domain.map(t => date(t).getTime()).includes(d.id) ? 2 : 1 : 0),
       y: 45 - 30 + 5 + 2
     });
     this._snapping = true;
@@ -80,6 +79,11 @@ export default class Timeline extends Axis {
       this._selection = single ? domain[0] : domain;
 
       const pixelDomain = domain.map(this._d3Scale);
+
+      if (this._buttons) {
+        pixelDomain[0] -= 0.5 * this._width / this._availableTicks.length - this._handleSize / 2;
+        pixelDomain[1] += 0.5 * this._width / this._availableTicks.length - this._handleSize / 2;
+      }
 
       if (single) {
         pixelDomain[0] -= 0.1;
@@ -112,16 +116,21 @@ export default class Timeline extends Axis {
     const ticks = this._availableTicks.map(Number);
     domain[0] = date(closest(domain[0], ticks));
     domain[1] = date(closest(domain[1], ticks));
-
+      
     const single = +domain[0] === +domain[1];
 
     if (this._brushing || !this._snapping) {
 
       const pixelDomain = domain.map(this._d3Scale);
-
+      
       if (single) {
         pixelDomain[0] -= 0.1;
         pixelDomain[1] += 0.1;
+      } 
+
+      if (this._buttons) {
+        pixelDomain[0] -= 0.5 * this._width / this._availableTicks.length - this._handleSize / 2;
+        pixelDomain[1] += 0.5 * this._width / this._availableTicks.length - this._handleSize / 2;
       }
 
       this._brushGroup.transition(this._transition).call(this._brush.move, pixelDomain);
@@ -161,6 +170,11 @@ export default class Timeline extends Axis {
         pixelDomain[1] += 0.1;
       }
 
+      if (this._buttons) {
+        pixelDomain[0] -= 0.5 * this._width / this._availableTicks.length - this._handleSize / 2;
+        pixelDomain[1] += 0.5 * this._width / this._availableTicks.length - this._handleSize / 2;
+      }
+
       this._brushGroup.call(this._brush.move, pixelDomain);
 
     }
@@ -195,18 +209,18 @@ export default class Timeline extends Axis {
       .call(attrize, this._handleConfig)
       .attr("height", timelineHeight + this._handleSize);
     
-    if (true) {
-      
+    if (this._buttons) {
 
       this._brushGroup.selectAll(".selection")
       .call(attrize, this._selectionConfig)
       .attr("height", timelineHeight)
       .attr("y", 7.5);
-    
+
       this._brushGroup.selectAll(".handle")
       .call(attrize, this._handleConfig)
       .attr("height", 30)
       .attr("y", 7.5);
+
     }
 
   }
@@ -225,8 +239,7 @@ export default class Timeline extends Axis {
 
     const offset = this._outerBounds[y],
           range = this._d3Scale.range();
-console.log(offset)
-console.log(range)
+
     const brush = this._brush = brushX()
       .extent([[range[0], offset], [range[1], offset + this._outerBounds[height]]])
       .filter(this._brushFilter)
@@ -248,14 +261,17 @@ console.log(range)
       selection[1] += 0.1;
     }
 
+    if (this._buttons) {
+      selection[0] -= 0.5 * this._width / this._availableTicks.length - this._handleSize / 2;
+      selection[1] += 0.5 * this._width / this._availableTicks.length - this._handleSize / 2;
+    }
+
     this._brushGroup = elem("g.brushGroup", {parent: this._group});
     this._brushGroup.call(brush).transition(this._transition)
       .call(brush.move, selection);
 
     this._outerBounds.y -= this._handleSize / 2;
     this._outerBounds.height += this._handleSize / 2;
-
-    console.log(this)
 
     return this;
 

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -7,7 +7,7 @@ import {brushX} from "d3-brush";
 import {event} from "d3-selection";
 
 import {Axis, date} from "d3plus-axis";
-import {attrize, closest, elem} from "d3plus-common";
+import {attrize, closest, elem, accessor, constant} from "d3plus-common";
 
 /**
     @class Timeline
@@ -26,7 +26,7 @@ export default class Timeline extends Axis {
 
     this._brushing = true;
     this._brushFilter = () => !event.button && event.detail < 2;
-    this._buttons = true;
+    this._buttons = constant(false);
     this._domain = [2001, 2010];
     this._gridSize = 0;
     this._handleConfig = {
@@ -44,7 +44,7 @@ export default class Timeline extends Axis {
     this._shape = "Rect";
     this._shapeConfig = Object.assign({}, this._shapeConfig, {
       fill: this._buttons ? "#EEE" : "#444",
-      height: d => this._buttons ? 30 : d.tick ? 10 : 0,
+      height: d => d.tick ? 10 : 0,
       width: d => this._buttons ? this._width / this._availableTicks.length : (d.tick ? this._domain.map(t => date(t).getTime()).includes(d.id) ? 2 : 1 : 0)
     });
     this._snapping = true;
@@ -53,9 +53,11 @@ export default class Timeline extends Axis {
       this._barConfig = {
         strokeWidth: 0
       };
-      this._shapeConfig.height = 30;
-      this._shapeConfig.labelBounds = {x: -20, y: -5, width: 40, height: 30};
-      this._shapeConfig.y = this._height - 30 + 5 + 2;
+      this._shapeConfig = Object.assign({}, this._shapeConfig, {
+        height: 30,
+        labelBounds: {x: -20, y: -5, width: 40, height: 30},
+        y: this._height - 30 + 5 + 2
+      });
     }
 
   }
@@ -230,6 +232,10 @@ export default class Timeline extends Axis {
 
     }
 
+  }
+
+  _draw() {
+    console.log("eduardo")
   }
 
   /**

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -242,9 +242,7 @@ export default class Timeline extends Axis {
     super.render(callback);
 
     const {height, y} = this._position;
-    const buttonBehavior = typeof this._buttonBehavior === "function" ? this._buttonBehavior(d => d) : this._buttonBehavior;
-    console.log(this._buttonBehavior)
-    this._buttonBehaviorCurrent = buttonBehavior === "buttons" || buttonBehavior === "auto" && this._availableTicks === this._visibleTicks ? "buttons" : "ticks";
+    this._buttonBehaviorCurrent = this._buttonBehavior === "buttons" || this._buttonBehavior === "auto" && this._availableTicks.length === this._visibleTicks.length ? "buttons" : "ticks";
 
     const offset = this._outerBounds[y],
           range = this._d3Scale.range();

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -6,6 +6,8 @@ import {max} from "d3-array";
 import {brushX} from "d3-brush";
 import {scaleTime} from "d3-scale";
 import {event} from "d3-selection";
+import {timeYear} from "d3-time";
+
 import {Axis, date} from "d3plus-axis";
 import {attrize, closest, elem} from "d3plus-common";
 import {textWidth, textWrap} from "d3plus-text";
@@ -31,6 +33,7 @@ export default class Timeline extends Axis {
     this._brushFilter = () => !event.button && event.detail < 2;
     this._buttonBehavior = "auto";
     this._buttonHeight = 30;
+    this._buttonPadding = 10;
     this._domain = [2001, 2010];
     this._gridSize = 0;
     this._handleConfig = {
@@ -226,9 +229,9 @@ export default class Timeline extends Axis {
       const ticks = this._ticks ? this._ticks.map(date) : this._domain.map(date);
       const d3Scale = scaleTime().domain(ticks).range([0, this._width]), 
             tickFormat = d3Scale.tickFormat();
-  
+
       // Measures size of ticks
-      ticksWidth = d3Scale.ticks().reduce((sum, d, i) => {
+      ticksWidth = d3Scale.ticks(timeYear).reduce((sum, d, i) => {
         const f = this._shapeConfig.labelConfig.fontFamily(d, i),
               s = this._shapeConfig.labelConfig.fontSize(d, i);
   
@@ -243,11 +246,11 @@ export default class Timeline extends Axis {
           : 0;
         if (width % 2) width++;
   
-        return sum + width;
+        return sum + width + 2 * this._buttonPadding;
       }, 0);
     }
 
-    this._buttonBehaviorCurrent = this._buttonBehavior === "auto" ? ticksWidth < this._width ? "buttons" : "ticks" : this._buttonBehavior;
+    this._buttonBehaviorCurrent = this._buttonBehavior === "auto" ? ticksWidth < this._width ? (this._width = ticksWidth, "buttons") : "ticks" : this._buttonBehavior;
 
     super.render(callback);
 

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -26,14 +26,15 @@ export default class Timeline extends Axis {
 
     this._brushing = true;
     this._brushFilter = () => !event.button && event.detail < 2;
-    this._buttons = constant(false);
+    this._buttonBehavior = "ticks";
+    this._buttonBehaviorCurrent =  this._buttonBehavior !== "auto" ? this._buttonBehavior : "buttons";
     this._domain = [2001, 2010];
     this._gridSize = 0;
     this._handleConfig = {
-      fill: this._buttons ? "#222" : "#444"
+      fill: this._buttonBehaviorCurrent === "buttons" ? "#222" : "#444"
     };
     this._handleSize = 6;
-    this._height = this._buttons ? 45 : 100;
+    this._height = this._buttonBehaviorCurrent === "buttons" ? 45 : 100;
     this._on = {};
     this.orient("bottom");
     this._scale = "time";
@@ -43,22 +44,22 @@ export default class Timeline extends Axis {
     };
     this._shape = "Rect";
     this._shapeConfig = Object.assign({}, this._shapeConfig, {
-      fill: this._buttons ? "#EEE" : "#444",
-      height: d => d.tick ? 10 : 0,
-      width: d => this._buttons ? this._width / this._availableTicks.length : (d.tick ? this._domain.map(t => date(t).getTime()).includes(d.id) ? 2 : 1 : 0)
-    });
+      fill: this._buttonBehaviorCurrent === "buttons" ? "#EEE" : "#444",
+      height: d => this._buttonBehaviorCurrent === "buttons" ? 30 : d.tick ? 10 : 0,
+      width: d => this._buttonBehaviorCurrent === "buttons" ? this._width / this._availableTicks.length : d.tick ? this._domain.map(t => date(t).getTime()).includes(d.id) ? 2 : 1 : 0
+    }, this._buttonBehaviorCurrent === "buttons" ? {
+      labelBounds: {x: -20, y: -5, width: 40, height: 30},
+      y: this._height - 30 + 5 + 2
+    } : {});
     this._snapping = true;
 
-    if (this._buttons) {
+    if (this._buttonBehaviorCurrent === "buttons") {
       this._barConfig = {
         strokeWidth: 0
       };
-      this._shapeConfig = Object.assign({}, this._shapeConfig, {
-        height: 30,
-        labelBounds: {x: -20, y: -5, width: 40, height: 30},
-        y: this._height - 30 + 5 + 2
-      });
     }
+
+    console.log(this._buttonBehaviorCurrent)
 
   }
 
@@ -86,7 +87,9 @@ export default class Timeline extends Axis {
 
       const pixelDomain = domain.map(this._d3Scale);
 
-      if (this._buttons) {
+      const buttons = this._buttonBehavior === "buttons" || this._buttonBehavior === "auto" && this._availableTicks === this._visibleTicks;
+
+      if (buttons) {
         const desv = 0.5 * (this._width / this._availableTicks.length - this._handleSize);
         pixelDomain[0] -= desv;
         pixelDomain[1] += desv;
@@ -135,7 +138,9 @@ export default class Timeline extends Axis {
         pixelDomain[1] += 0.1;
       } 
 
-      if (this._buttons) {
+      const buttons = this._buttonBehavior === "buttons" || this._buttonBehavior === "auto" && this._availableTicks === this._visibleTicks;
+
+      if (buttons) {
         const desv = 0.5 * (this._width / this._availableTicks.length - this._handleSize);
         pixelDomain[0] -= desv;
         pixelDomain[1] += desv;
@@ -178,7 +183,9 @@ export default class Timeline extends Axis {
         pixelDomain[1] += 0.1;
       }
 
-      if (this._buttons) {
+      const buttons = this._buttonBehavior === "buttons" || this._buttonBehavior === "auto" && this._availableTicks === this._visibleTicks;
+
+      if (buttons) {
         const desv = 0.5 * (this._width / this._availableTicks.length - this._handleSize);
         pixelDomain[0] -= desv;
         pixelDomain[1] += desv;
@@ -218,7 +225,9 @@ export default class Timeline extends Axis {
       .call(attrize, this._handleConfig)
       .attr("height", timelineHeight + this._handleSize);
     
-    if (this._buttons) {
+    const buttons = this._buttonBehavior === "buttons" || this._buttonBehavior === "auto" && this._availableTicks === this._visibleTicks;
+    
+    if (buttons) {
 
       this._brushGroup.selectAll(".selection")
       .call(attrize, this._selectionConfig)
@@ -234,10 +243,6 @@ export default class Timeline extends Axis {
 
   }
 
-  _draw() {
-    console.log("eduardo")
-  }
-
   /**
       @memberof Timeline
       @desc Draws the timeline.
@@ -247,6 +252,8 @@ export default class Timeline extends Axis {
   render(callback) {
 
     super.render(callback);
+
+    this._buttonBehaviorCurrent = this._buttonBehavior === "buttons" || this._buttonBehavior === "auto" && this._availableTicks === this._visibleTicks ? "buttons" : "ticks";
 
     const {height, y} = this._position;
 
@@ -274,7 +281,9 @@ export default class Timeline extends Axis {
       selection[1] += 0.1;
     }
 
-    if (this._buttons) {
+    const buttons = this._buttonBehavior === "buttons" || this._buttonBehavior === "auto" && this._availableTicks === this._visibleTicks;
+
+    if (buttons) {
       const desv = 0.5 * (this._width / this._availableTicks.length - this._handleSize);
       selection[0] -= desv;
       selection[1] += desv;
@@ -321,8 +330,8 @@ function() {
       @param {Boolean} [*value* = false]
       @chainable
   */
-  buttons(_) {
-    return arguments.length ? (this._buttons = _, this) : this._buttons;
+  buttonBehavior(_) {
+    return arguments.length ? (this._buttonBehavior = _, this) : this._buttonBehavior;
   }
 
 

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -238,22 +238,16 @@ export default class Timeline extends Axis {
         .lineHeight(this._shapeConfig.lineHeight ? this._shapeConfig.lineHeight(d, i) : undefined);
 
       const res = wrap(tickFormat(d));
-      res.lines = res.lines.filter(d => d !== "");
-      res.d = d;
-      res.fS = s;
       res.width = res.lines.length
         ? Math.ceil(max(res.lines.map(line => textWidth(line, {"font-family": f, "font-size": s})))) + s / 4
         : 0;
-      res.height = res.lines.length ? Math.ceil(res.lines.length * (wrap.lineHeight() + 1)) : 0;
-      res.offset = 0;
-      res.hidden = false;
       if (res.width % 2) res.width++;
 
       return res;
-
     });
 
     const ticksWidth = textData.reduce((d, i) => d + i.width, 0);
+    console.log(ticksWidth)
 
     this._buttonBehaviorCurrent = this._buttonBehavior === "auto" ? ticksWidth < this._width ? "buttons" : "ticks" : this._buttonBehavior;
 
@@ -317,8 +311,8 @@ function() {
 
   /**
       @memberof Timeline
-      @desc If *value* is specified, toggles the buttons value and returns the current class instance. If *value* is not specified, returns the current button value.
-      @param {String} [*value* = "ticks"]
+      @desc If *value* is specified, toggles the style of the timeline. Accepted values are `"auto"`, `"buttons"` and `"ticks"`. If *value* is not specified, returns the current button value.
+      @param {String} [*value* = "auto"]
       @chainable
   */
   buttonBehavior(_) {

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -225,7 +225,6 @@ export default class Timeline extends Axis {
 
     if (this._ticks && !this._labels) this.labels(this._ticks);
 
-
     if (this._buttonBehavior === "auto") {
       let ticks = this._ticks ? this._ticks.map(date) : this._domain.map(date);
       const d3Scale = scaleTime().domain(ticks).range([0, this._width]), 

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -197,7 +197,7 @@ export default class Timeline extends Axis {
 
   /**
       @memberof Timeline
-      @desc Update interval of brush.
+      @desc Update limits of the brush.
       @private
   */
   _updateBrushLimit(selection) {
@@ -255,14 +255,12 @@ export default class Timeline extends Axis {
 
     const ticksWidth = textData.reduce((d, i) => d + i.width, 0);
 
-    this._buttonBehaviorCurrent = this._buttonBehavior === "buttons" || this._buttonBehavior === "auto" && ticksWidth < this._width ? "buttons" : "ticks";
+    this._buttonBehaviorCurrent = this._buttonBehavior === "auto" ? ticksWidth < this._width ? "buttons" : "ticks" : this._buttonBehavior;
 
     super.render(callback);
 
     const offset = this._outerBounds[y],
           range = this._d3Scale.range();
-
-    this._buttonBehaviorAuto = this._buttonBehavior === "auto" ? this._availableTicks === this._visibleTicks ? "buttons" : "ticks" : this._buttonBehavior;
 
     const brush = this._brush = brushX()
       .extent([[range[0], offset], [range[1], offset + this._outerBounds[height]]])


### PR DESCRIPTION
(closes #31)

### Description
This new feature for d3plus creates a button behavior in timeline, letting to change between ticks and buttons.

To create this feature, I updated `brushStart`, `brushEnd` and `brushBrush` functions when behavior in timeline is `"button"`. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [x] I have written examples for all new methods/functionality.

