### PR TITLE
solves bug using timeline in viz

### DIFF
--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -25,7 +25,7 @@ export default class Timeline extends Axis {
   constructor() {
 
     super();
-    this._align = "middle";
+
     this._barConfig = Object.assign({}, this._barConfig, {
       "stroke-width": () => this._buttonBehaviorCurrent === "buttons" ? 0 : 1
     });

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -25,7 +25,7 @@ export default class Timeline extends Axis {
   constructor() {
 
     super();
-    this._align = () => this._buttonBehaviorCurrent === "buttons" ? "middle" : "start";
+    this._align = "middle";
     this._barConfig = Object.assign({}, this._barConfig, {
       "stroke-width": () => this._buttonBehaviorCurrent === "buttons" ? 0 : 1
     });
@@ -315,18 +315,17 @@ export default class Timeline extends Axis {
       const d3Scale = scaleTime().domain(ticks).range([0, this._ticksWidth]);
       ticks = this._ticks ? ticks : d3Scale.ticks();
 
-      const align = typeof this._align === "function" ? this._align() : this._align,
-            buttonMargin = 0.5 * this._ticksWidth / ticks.length;
+      const buttonMargin = 0.5 * this._ticksWidth / ticks.length;
 
-      this._marginLeft = align === "middle" 
-        ? (this._width - this._ticksWidth) / 2 : align === "end" 
+      this._marginLeft = this._align === "middle" 
+        ? (this._width - this._ticksWidth) / 2 : this._align === "end" 
           ? this._width - this._ticksWidth : 0;
 
-      const marginRight = align === "middle"
-        ? (this._width + this._ticksWidth) / 2 - buttonMargin : align === "start" 
+      const marginRight = this._align === "middle"
+        ? (this._width + this._ticksWidth) / 2 - buttonMargin : this._align === "start" 
           ? this._ticksWidth - buttonMargin : undefined;
 
-      this._range = [align === "start" ? undefined : this._marginLeft + buttonMargin, marginRight]; 
+      this._range = [this._align === "start" ? undefined : this._marginLeft + buttonMargin, marginRight]; 
     }
     
     if (this._buttonBehaviorCurrent === "buttons") {

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -75,31 +75,34 @@ export default class Timeline extends Axis {
               ? event.selection 
               : [event.selection[0] + buttonDomain, event.selection[1] - buttonDomain].sort((a, b) => a - b);
 
-      const domain = (this._brushing ? selection
+      const domain = (this._brushing 
+        ? selection
         : this._buttonBehaviorCurrent === "buttons" 
           ? [event.sourceEvent.offsetX, event.sourceEvent.offsetX] : [event.selection[0], event.selection[0]])
-        //.map(this._d3Scale.invert)
         .map(Number);
+      
+      if (this._buttonBehaviorCurrent === "ticks") domain.map(this._d3Scale.invert);
 
-      //const ticks = this._availableTicks.map(Number);
-      const ticks = this._availableTicks.map((d, i) => this._marginLeft + (i + 0.5) * this._ticksWidth / this._availableTicks.length)
-      //domain[0] = date(closest(domain[0], ticks));
-      //domain[1] = date(closest(domain[1], ticks));
-      domain[0] = closest(domain[0], ticks);
-      domain[1] = closest(domain[1], ticks);
+      const ticks = this._buttonBehaviorCurrent === "ticks"
+        ? this._availableTicks.map(Number) 
+        : this._availableTicks.map((d, i) => this._marginLeft + (i + 0.5) * this._ticksWidth / this._availableTicks.length);
+
+      if (this._buttonBehaviorCurrent === "ticks") {
+        domain[0] = date(closest(domain[0], ticks));
+        domain[1] = date(closest(domain[1], ticks));
+      } 
+      else {
+        domain[0] = closest(domain[0], ticks);
+        domain[1] = closest(domain[1], ticks);
+      }
 
       const single = +domain[0] === +domain[1];
-
       this._selection = single ? domain[0] : domain;
 
-      //const pixelDomain = domain.map(this._d3Scale);
-      const pixelDomain = domain;
-      console.log("brush")
-      console.log(domain)
-      console.log(pixelDomain)
-      //this._updateBrushLimit(pixelDomain);
-      console.log(pixelDomain)
-      this._brushGroup.call(this._brush.move, pixelDomain.sort((a, b) => a - b));
+      const pixelDomain = this._buttonBehaviorCurrent === "ticks" ? domain.map(this._d3Scale) : domain;
+      this._updateBrushLimit(pixelDomain);
+      
+      this._brushGroup.call(this._brush.move, pixelDomain);
 
     }
 
@@ -119,23 +122,28 @@ export default class Timeline extends Axis {
 
     const domain = (event.selection && this._brushing ? event.selection
       : [event.sourceEvent.offsetX, event.sourceEvent.offsetX])
-      //.map(this._d3Scale.invert)
       .map(Number);
 
-    //const ticks = this._availableTicks.map(Number);
-    const ticks = this._availableTicks.map((d, i) => this._marginLeft + (i + 0.5) * this._ticksWidth / this._availableTicks.length)
-    //domain[0] = date(closest(domain[0], ticks));
-    //domain[1] = date(closest(domain[1], ticks));
-    domain[0] = closest(domain[0], ticks);
-    domain[1] = closest(domain[1], ticks);
+    if (this._buttonBehaviorCurrent === "ticks") domain.map(this._d3Scale.invert);
+
+    const ticks = this._buttonBehaviorCurrent === "ticks"
+      ? this._availableTicks.map(Number) 
+      : this._availableTicks.map((d, i) => this._marginLeft + (i + 0.5) * this._ticksWidth / this._availableTicks.length);
+
+    if (this._buttonBehaviorCurrent === "ticks") {
+      domain[0] = date(closest(domain[0], ticks));
+      domain[1] = date(closest(domain[1], ticks));
+    } 
+    else {
+      domain[0] = closest(domain[0], ticks);
+      domain[1] = closest(domain[1], ticks);
+    }
+
     const single = +domain[0] === +domain[1];
 
     if (this._brushing || !this._snapping) {
 
-      const pixelDomain = domain;
-      console.log("end")
-      console.log(domain)
-      console.log(pixelDomain)
+      const pixelDomain = this._buttonBehaviorCurrent === "ticks" ? domain.map(this._d3Scale) : domain;
       this._updateBrushLimit(pixelDomain);
 
       this._brushGroup.transition(this._transition).call(this._brush.move, pixelDomain);
@@ -156,25 +164,26 @@ export default class Timeline extends Axis {
   _brushStart() {
 
     if (event.sourceEvent !== null && (!this._brushing || this._snapping)) {
-
       const domain = (event.selection && this._brushing ? event.selection
         : [event.sourceEvent.offsetX, event.sourceEvent.offsetX])
-        //.map(this._d3Scale.invert)
         .map(Number);
 
-      //const ticks = this._availableTicks.map(Number);
-      const ticks = this._availableTicks.map((d, i) => this._marginLeft + (i + 0.5) * this._ticksWidth / this._availableTicks.length)
-      //domain[0] = date(closest(domain[0], ticks));
-      //domain[1] = date(closest(domain[1], ticks));
+      if (this._buttonBehaviorCurrent === "ticks") domain.map(this._d3Scale.invert);
 
-      domain[0] = closest(domain[0], ticks);
-      domain[1] = closest(domain[1], ticks);
-        console.log(ticks)
-      //const pixelDomain = domain.map(this._d3Scale);
-      const pixelDomain = domain;
-      console.log("start")
-      console.log(domain)
-      console.log(pixelDomain)
+      const ticks = this._buttonBehaviorCurrent === "ticks"
+        ? this._availableTicks.map(Number) 
+        : this._availableTicks.map((d, i) => this._marginLeft + (i + 0.5) * this._ticksWidth / this._availableTicks.length);
+
+      if (this._buttonBehaviorCurrent === "ticks") {
+        domain[0] = date(closest(domain[0], ticks));
+        domain[1] = date(closest(domain[1], ticks));
+      } 
+      else {
+        domain[0] = closest(domain[0], ticks);
+        domain[1] = closest(domain[1], ticks);
+      }
+
+      const pixelDomain = this._buttonBehaviorCurrent === "ticks" ? domain.map(this._d3Scale) : domain;
       this._updateBrushLimit(pixelDomain);
 
       this._brushGroup.call(this._brush.move, pixelDomain);
@@ -306,28 +315,38 @@ export default class Timeline extends Axis {
 
       this._range = [align === "start" ? undefined : this._marginLeft + buttonMargin, marginRight]; 
     }
-    this._scale = "ordinal";
-    this._domain = this._ticks;
+    
+    if (this._buttonBehaviorCurrent === "buttons") {
+      this._scale = "ordinal";
+      this._domain = this._ticks;
+    }
     super.render(callback);
 
     const offset = this._outerBounds[y],
           range = this._d3Scale.range();
-
+    console.log(this._domain)
+    console.log(range)
+    console.log(offset)
     const brush = this._brush = brushX()
-      .extent([[range[0], offset], [range[1], offset + this._outerBounds[height]]])
+      .extent([[range[0], offset], [range[range.length - 1], offset + this._outerBounds[height]]])
       .filter(this._brushFilter)
       .handleSize(this._handleSize)
       .on("start", this._brushStart.bind(this))
       .on("brush", this._brushBrush.bind(this))
       .on("end", this._brushEnd.bind(this));
 
-    const latest = this._availableTicks[this._availableTicks.length - 1];
-    const selection = (this._selection === void 0 ? [latest, latest]
+    const latest = this._buttonBehaviorCurrent === "ticks"
+      ? this._availableTicks[this._availableTicks.length - 1]
+      : this._marginLeft + (range.length - 0.5) * this._ticksWidth / this._availableTicks.length;
+
+    const selection = this._selection === void 0 ? [latest, latest]
       : this._selection instanceof Array
         ? this._selection.slice()
-        : [this._selection, this._selection])
-      .map(date)
-      .map(this._d3Scale);
+        : [this._selection, this._selection];
+      
+    if (this._buttonBehaviorCurrent === "ticks") {
+      selection.map(date).map(this._d3Scale);
+    }
 
     this._updateBrushLimit(selection);
 

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -274,6 +274,9 @@ export default class Timeline extends Axis {
     if (this._buttonBehaviorCurrent === "buttons") {
       if (!this._ticks) this._ticks = Array.from(Array(this._domain[this._domain.length - 1] - this._domain[0] + 1), (_, x) => this._domain[0] + x);
       if (!this._brushing) this._handleSize = 0;
+
+      this._scale = "ordinal";
+      this._domain = this._ticks;
     }
 
     if (this._ticksWidth && this._buttonBehaviorCurrent === "buttons") {
@@ -293,11 +296,7 @@ export default class Timeline extends Axis {
 
       this._range = [this._align === "start" ? undefined : this._marginLeft + buttonMargin, marginRight]; 
     }
-    
-    if (this._buttonBehaviorCurrent === "buttons") {
-      this._scale = "ordinal";
-      this._domain = this._ticks;
-    }
+
     super.render(callback);
 
     const offset = this._outerBounds[y],

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -8,7 +8,7 @@ import {scaleTime} from "d3-scale";
 import {event} from "d3-selection";
 
 import {Axis, date} from "d3plus-axis";
-import {attrize, closest, elem} from "d3plus-common";
+import {accessor, attrize, closest, constant, elem} from "d3plus-common";
 import {textWidth, textWrap} from "d3plus-text";
 
 /**
@@ -25,6 +25,7 @@ export default class Timeline extends Axis {
   constructor() {
 
     super();
+    this._align = () => this._buttonBehaviorCurrent === "buttons" ? "middle" : "start";
     this._barConfig = Object.assign({}, this._barConfig, {
       "stroke-width": () => this._buttonBehaviorCurrent === "buttons" ? 0 : 1
     });
@@ -264,26 +265,27 @@ export default class Timeline extends Axis {
       this.labels(this._ticks);
     }
 
+    if (this._buttonBehaviorCurrent === "buttons") {
+      if (!this._brushing) this._handleSize = 0;
+    }
+
     if (this._ticksWidth && this._buttonBehaviorCurrent === "buttons") {
       let ticks = this._ticks ? this._ticks.map(date) : this._domain.map(date);
       const d3Scale = scaleTime().domain(ticks).range([0, this._ticksWidth]);
       ticks = this._ticks ? ticks : d3Scale.ticks();
 
-      const buttonMargin = 0.5 * this._ticksWidth / ticks.length;
+      const align = typeof this._align === "function" ? this._align() : this._align,
+            buttonMargin = 0.5 * this._ticksWidth / ticks.length;
 
-      this._marginLeft = this._align === "middle" 
-        ? (this._width - this._ticksWidth) / 2 : this._align === "end" 
+      this._marginLeft = align === "middle" 
+        ? (this._width - this._ticksWidth) / 2 : align === "end" 
           ? this._width - this._ticksWidth : 0;
 
-      const marginRight = this._align === "middle"
-        ? (this._width + this._ticksWidth) / 2 - buttonMargin : this._align === "start" 
+      const marginRight = align === "middle"
+        ? (this._width + this._ticksWidth) / 2 - buttonMargin : align === "start" 
           ? this._ticksWidth - buttonMargin : undefined;
 
-      this._range = [this._align === "start" ? undefined : this._marginLeft + buttonMargin, marginRight]; 
-    }
-
-    if (this._buttonBehaviorCurrent === "buttons" && !this._brushing) {
-      this._handleSize = 0;
+      this._range = [align === "start" ? undefined : this._marginLeft + buttonMargin, marginRight]; 
     }
 
     super.render(callback);
@@ -319,6 +321,10 @@ export default class Timeline extends Axis {
     return this;
 
   }
+
+  /*align(_) {
+    return arguments.length ? (this._align = typeof _ === "function" ? _ : accessor(_), this) : this._align;
+  }*/
 
   /**
       @memberof Timeline

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -170,8 +170,12 @@ export default class Timeline extends Axis {
         : [event.sourceEvent.offsetX, event.sourceEvent.offsetX]).map(Number);
     
     if (event.type === "brush" && this._brushing && this._buttonBehaviorCurrent === "buttons") {
-      const buttonDomain = 0.5 * (this._ticksWidth / this._availableTicks.length - this._handleSize + 0.2);
-      domain = [event.selection[0] + buttonDomain, event.selection[1] - buttonDomain].sort((a, b) => a - b);
+      const diffs = event.selection.map(d => Math.abs(d - event.sourceEvent.offsetX));
+
+      domain = diffs[1] <= diffs[0] 
+        ? [event.selection[0], event.sourceEvent.offsetX].sort((a, b) => a - b)
+        : [event.sourceEvent.offsetX, event.selection[1]].sort((a, b) => a - b);
+
     }
 
     const ticks = this._buttonBehaviorCurrent === "ticks"
@@ -239,6 +243,7 @@ export default class Timeline extends Axis {
             tickFormat = d3Scale.tickFormat();
 
       ticks = this._ticks ? ticks : d3Scale.ticks();
+
       // Measures size of ticks
       this._ticksWidth = ticks.reduce((sum, d, i) => {
         const f = this._shapeConfig.labelConfig.fontFamily(d, i),

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -100,8 +100,8 @@ export default class Timeline extends Axis {
       this._selection = this._buttonBehaviorCurrent === "ticks" 
         ? single ? domain[0] : domain 
         : single 
-          ? new Date(this._availableTicks[ticks.indexOf(domain[0])], 0, 1) 
-          : [new Date(this._availableTicks[ticks.indexOf(domain[0])], 0, 1), new Date(this._availableTicks[ticks.indexOf(domain[1])], 0, 1)];
+          ? date(this._availableTicks[ticks.indexOf(domain[0])]) 
+          : [date(this._availableTicks[ticks.indexOf(domain[0])]), date(this._availableTicks[ticks.indexOf(domain[1])])];
 
       const pixelDomain = this._buttonBehaviorCurrent === "ticks" ? domain.map(this._d3Scale) : domain;
       this._updateBrushLimit(pixelDomain);
@@ -160,8 +160,8 @@ export default class Timeline extends Axis {
     this._selection = this._buttonBehaviorCurrent === "ticks" 
       ? single ? domain[0] : domain 
       : single 
-        ? new Date(this._availableTicks[ticks.indexOf(domain[0])], 0, 1) 
-        : [new Date(this._availableTicks[ticks.indexOf(domain[0])], 0, 1), new Date(this._availableTicks[ticks.indexOf(domain[1])], 0, 1)];
+        ? date(this._availableTicks[ticks.indexOf(domain[0])]) 
+        : [date(this._availableTicks[ticks.indexOf(domain[0])]), date(this._availableTicks[ticks.indexOf(domain[1])])];
 
     if (this._on.end) this._on.end(this._selection);
 

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -78,22 +78,28 @@ export default class Timeline extends Axis {
       const domain = (this._brushing ? selection
         : this._buttonBehaviorCurrent === "buttons" 
           ? [event.sourceEvent.offsetX, event.sourceEvent.offsetX] : [event.selection[0], event.selection[0]])
-        .map(this._d3Scale.invert)
+        //.map(this._d3Scale.invert)
         .map(Number);
 
-      const ticks = this._availableTicks.map(Number);
-
-      domain[0] = date(closest(domain[0], ticks));
-      domain[1] = date(closest(domain[1], ticks));
+      //const ticks = this._availableTicks.map(Number);
+      const ticks = this._availableTicks.map((d, i) => this._marginLeft + (i + 0.5) * this._ticksWidth / this._availableTicks.length)
+      //domain[0] = date(closest(domain[0], ticks));
+      //domain[1] = date(closest(domain[1], ticks));
+      domain[0] = closest(domain[0], ticks);
+      domain[1] = closest(domain[1], ticks);
 
       const single = +domain[0] === +domain[1];
 
       this._selection = single ? domain[0] : domain;
 
-      const pixelDomain = domain.map(this._d3Scale);
-      this._updateBrushLimit(pixelDomain);
-
-      this._brushGroup.call(this._brush.move, pixelDomain);
+      //const pixelDomain = domain.map(this._d3Scale);
+      const pixelDomain = domain;
+      console.log("brush")
+      console.log(domain)
+      console.log(pixelDomain)
+      //this._updateBrushLimit(pixelDomain);
+      console.log(pixelDomain)
+      this._brushGroup.call(this._brush.move, pixelDomain.sort((a, b) => a - b));
 
     }
 
@@ -113,18 +119,23 @@ export default class Timeline extends Axis {
 
     const domain = (event.selection && this._brushing ? event.selection
       : [event.sourceEvent.offsetX, event.sourceEvent.offsetX])
-      .map(this._d3Scale.invert)
+      //.map(this._d3Scale.invert)
       .map(Number);
 
-    const ticks = this._availableTicks.map(Number);
-    domain[0] = date(closest(domain[0], ticks));
-    domain[1] = date(closest(domain[1], ticks));
-      
+    //const ticks = this._availableTicks.map(Number);
+    const ticks = this._availableTicks.map((d, i) => this._marginLeft + (i + 0.5) * this._ticksWidth / this._availableTicks.length)
+    //domain[0] = date(closest(domain[0], ticks));
+    //domain[1] = date(closest(domain[1], ticks));
+    domain[0] = closest(domain[0], ticks);
+    domain[1] = closest(domain[1], ticks);
     const single = +domain[0] === +domain[1];
 
     if (this._brushing || !this._snapping) {
 
-      const pixelDomain = domain.map(this._d3Scale);
+      const pixelDomain = domain;
+      console.log("end")
+      console.log(domain)
+      console.log(pixelDomain)
       this._updateBrushLimit(pixelDomain);
 
       this._brushGroup.transition(this._transition).call(this._brush.move, pixelDomain);
@@ -148,14 +159,22 @@ export default class Timeline extends Axis {
 
       const domain = (event.selection && this._brushing ? event.selection
         : [event.sourceEvent.offsetX, event.sourceEvent.offsetX])
-        .map(this._d3Scale.invert)
+        //.map(this._d3Scale.invert)
         .map(Number);
 
-      const ticks = this._availableTicks.map(Number);
-      domain[0] = date(closest(domain[0], ticks));
-      domain[1] = date(closest(domain[1], ticks));
+      //const ticks = this._availableTicks.map(Number);
+      const ticks = this._availableTicks.map((d, i) => this._marginLeft + (i + 0.5) * this._ticksWidth / this._availableTicks.length)
+      //domain[0] = date(closest(domain[0], ticks));
+      //domain[1] = date(closest(domain[1], ticks));
 
-      const pixelDomain = domain.map(this._d3Scale);
+      domain[0] = closest(domain[0], ticks);
+      domain[1] = closest(domain[1], ticks);
+        console.log(ticks)
+      //const pixelDomain = domain.map(this._d3Scale);
+      const pixelDomain = domain;
+      console.log("start")
+      console.log(domain)
+      console.log(pixelDomain)
       this._updateBrushLimit(pixelDomain);
 
       this._brushGroup.call(this._brush.move, pixelDomain);
@@ -287,7 +306,8 @@ export default class Timeline extends Axis {
 
       this._range = [align === "start" ? undefined : this._marginLeft + buttonMargin, marginRight]; 
     }
-
+    this._scale = "ordinal";
+    this._domain = this._ticks;
     super.render(callback);
 
     const offset = this._outerBounds[y],
@@ -321,10 +341,6 @@ export default class Timeline extends Axis {
     return this;
 
   }
-
-  /*align(_) {
-    return arguments.length ? (this._align = typeof _ === "function" ? _ : accessor(_), this) : this._align;
-  }*/
 
   /**
       @memberof Timeline


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
(closes d3plus/d3plus-viz#94)
(closes #19)

### Description
The bug was caused because the current behavior in button timeline only accepted correlatives values. For to solve it, I set the buttonBehavior with ordinal scale, and I rewrite the logic behind selections and domains using buttons. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

