### PR TITLE
solves weird behavior in button widths

### DIFF
--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -33,7 +33,6 @@ export default class Timeline extends Axis {
     this._brushFilter = () => !event.button && event.detail < 2;
     this._buttonBehavior = "auto";
     this._buttonHeight = 30;
-    this._buttonPadding = 12;
     this._domain = [2001, 2010];
     this._gridSize = 0;
     this._handleConfig = {
@@ -43,6 +42,7 @@ export default class Timeline extends Axis {
     this._height = 100;
     this._on = {};
     this.orient("bottom");
+    this._padding = 10;
     this._scale = "time";
     this._selectionConfig = {
       "fill": "#777",
@@ -239,7 +239,8 @@ export default class Timeline extends Axis {
 
     if (this._buttonBehavior !== "ticks") {
       let ticks = this._ticks ? this._ticks.map(date) : this._domain.map(date);
-      const d3Scale = scaleTime().domain(ticks).range([0, this._width]), 
+      const d3Scale = scaleTime().domain(ticks).range([0, this._width]),
+            padding = this._padding || 10,
             tickFormat = d3Scale.tickFormat();
 
       ticks = this._ticks ? ticks : d3Scale.ticks();
@@ -260,7 +261,7 @@ export default class Timeline extends Axis {
           ? Math.ceil(max(res.lines.map(line => textWidth(line, {"font-family": f, "font-size": s})))) + s / 4
           : 0;
         if (width % 2) width++;
-        return sum + width + 2 * this._buttonPadding;
+        return sum + width + 2 * padding;
       }, 0);
     }
 
@@ -272,14 +273,13 @@ export default class Timeline extends Axis {
     }
 
     if (this._buttonBehaviorCurrent === "buttons") {
-      if (!this._ticks) this._ticks = Array.from(Array(this._domain[this._domain.length - 1] - this._domain[0] + 1), (_, x) => this._domain[0] + x);
       if (!this._brushing) this._handleSize = 0;
+      if (!this._padding) this._padding = 10;
+      if (!this._ticks) this._ticks = Array.from(Array(this._domain[this._domain.length - 1] - this._domain[0] + 1), (_, x) => this._domain[0] + x);
 
       this._scale = "ordinal";
       this._domain = this._ticks.sort((a, b) => a - b);
-    }
 
-    if (this._ticksWidth && this._buttonBehaviorCurrent === "buttons") {
       let ticks = this._ticks ? this._ticks.map(date) : this._domain.map(date);
       const d3Scale = scaleTime().domain(ticks).range([0, this._ticksWidth]);
       ticks = this._ticks ? ticks : d3Scale.ticks();
@@ -294,7 +294,6 @@ export default class Timeline extends Axis {
         ? (this._width + this._ticksWidth) / 2 - buttonMargin : this._align === "start" 
           ? this._ticksWidth - buttonMargin : undefined;
 
-      this._padding = this._buttonPadding;
       this._range = [this._align === "start" ? undefined : this._marginLeft + buttonMargin, marginRight];
     }
 
@@ -375,16 +374,6 @@ function() {
     */
   buttonHeight(_) {
     return arguments.length ? (this._buttonHeight = _, this) : this._buttonHeight;
-  }
-
-  /**
-        @memberof Timeline
-        @desc If *value* is specified, sets the button padding and returns the current class instance. If *value* is not specified, returns the current button padding.
-        @param {Number} [*value* = 10]
-        @chainable
-    */
-  buttonPadding(_) {
-    return arguments.length ? (this._buttonPadding = _, this) : this._buttonPadding;
   }
 
   /**

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -239,7 +239,6 @@ export default class Timeline extends Axis {
     if (this._buttonBehavior !== "ticks") {
       let ticks = this._ticks ? this._ticks.map(date) : this._domain.map(date);
       const d3Scale = scaleTime().domain(ticks).range([0, this._width]),
-            padding = this._padding >= 10 ? this._padding : 10,
             tickFormat = d3Scale.tickFormat();
 
       ticks = this._ticks ? ticks : d3Scale.ticks();
@@ -260,7 +259,7 @@ export default class Timeline extends Axis {
           ? Math.ceil(max(res.lines.map(line => textWidth(line, {"font-family": f, "font-size": s})))) + s / 4
           : 0;
         if (width % 2) width++;
-        return sum + width + 2 * padding;
+        return sum + width + 2 * this._padding;
       }, 0);
     }
 
@@ -290,7 +289,7 @@ export default class Timeline extends Axis {
           ? this._width - this._ticksWidth : 0;
 
       const marginRight = this._align === "middle"
-        ? (this._width + this._ticksWidth) / 2 - buttonMargin : this._align === "start" 
+        ? (this._width + this._ticksWidth) / 2 : this._align === "start" 
           ? this._ticksWidth - buttonMargin : undefined;
 
       this._range = [this._align === "start" ? undefined : this._marginLeft + buttonMargin, marginRight];

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -42,7 +42,6 @@ export default class Timeline extends Axis {
     this._height = 100;
     this._on = {};
     this.orient("bottom");
-    this._padding = 10;
     this._scale = "time";
     this._selectionConfig = {
       "fill": "#777",
@@ -240,7 +239,7 @@ export default class Timeline extends Axis {
     if (this._buttonBehavior !== "ticks") {
       let ticks = this._ticks ? this._ticks.map(date) : this._domain.map(date);
       const d3Scale = scaleTime().domain(ticks).range([0, this._width]),
-            padding = this._padding || 10,
+            padding = this._padding >= 10 ? this._padding : 10,
             tickFormat = d3Scale.tickFormat();
 
       ticks = this._ticks ? ticks : d3Scale.ticks();

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -291,7 +291,7 @@ export default class Timeline extends Axis {
 
       const marginRight = this._align === "middle"
         ? (this._width + this._ticksWidth) / 2 : this._align === "start" 
-          ? this._ticksWidth - buttonMargin : undefined;
+          ? this._ticksWidth : undefined;
 
       this._range = [this._align === "start" ? undefined : this._marginLeft + buttonMargin, marginRight];
     }

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -276,7 +276,7 @@ export default class Timeline extends Axis {
       if (!this._brushing) this._handleSize = 0;
 
       this._scale = "ordinal";
-      this._domain = this._ticks;
+      this._domain = this._ticks.sort((a, b) => a - b);
     }
 
     if (this._ticksWidth && this._buttonBehaviorCurrent === "buttons") {
@@ -294,7 +294,8 @@ export default class Timeline extends Axis {
         ? (this._width + this._ticksWidth) / 2 - buttonMargin : this._align === "start" 
           ? this._ticksWidth - buttonMargin : undefined;
 
-      this._range = [this._align === "start" ? undefined : this._marginLeft + buttonMargin, marginRight]; 
+      this._padding = this._buttonPadding;
+      this._range = [this._align === "start" ? undefined : this._marginLeft + buttonMargin, marginRight];
     }
 
     super.render(callback);

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -32,6 +32,7 @@ export default class Timeline extends Axis {
     this._brushing = true;
     this._brushFilter = () => !event.button && event.detail < 2;
     this._buttonBehavior = "auto";
+    this._buttonPadding = 10;
     this._buttonHeight = 30;
     this._domain = [2001, 2010];
     this._gridSize = 0;
@@ -259,7 +260,7 @@ export default class Timeline extends Axis {
           ? Math.ceil(max(res.lines.map(line => textWidth(line, {"font-family": f, "font-size": s})))) + s / 4
           : 0;
         if (width % 2) width++;
-        return sum + width + 2 * this._padding;
+        return sum + width + 2 * this._buttonPadding;
       }, 0);
     }
 
@@ -328,6 +329,16 @@ export default class Timeline extends Axis {
 
     return this;
 
+  }
+
+  /**
+        @memberof Timeline
+        @desc If *value* is specified, sets the button padding and returns the current class instance. If *value* is not specified, returns the current button padding.
+        @param {Number} [*value* = 10]
+        @chainable
+    */
+  buttonPadding(_) {
+    return arguments.length ? (this._buttonPadding = _, this) : this._buttonPadding;
   }
 
   /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
closes #36 

### Description
<!--- Describe your changes in detail -->
This bug was caused because the logic behind of `x position` in Axis.js was calculated with `this._padding` and in Timeline buttons we were using `this._buttonPadding`.

For to solve it, I deleted `this._buttonPadding`, and now we're using `this._padding`. The only additional thing that I had to make was set a minimal value of padding in buttons.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

