### PR TITLE
fixes buttons when the user specifies the ticks

### DIFF
--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -276,7 +276,7 @@ export default class Timeline extends Axis {
       if (!this._brushing) this._handleSize = 0;
       const domain = this._domain.map(date).map(this._tickFormat).map(Number);
 
-      this._domain = Array.from(Array(domain[domain.length - 1] - domain[0] + 1), (_, x) => domain[0] + x).map(date);
+      this._domain = this._ticks ? this._ticks.map(date) : Array.from(Array(domain[domain.length - 1] - domain[0] + 1), (_, x) => domain[0] + x).map(date);
       this._ticks = this._domain;
 
       const buttonMargin = 0.5 * this._ticksWidth / this._ticks.length;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
closes #40 

### Description
<!--- Describe your changes in detail -->
This bug was caused because we weren't using the ticks passed by the user in buttons. For to solve it, I checked if the user sets ticks and I updated `this._domain`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

