### PR TITLE
adds tickSpecified method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "d3plus-timeline",
-  "version": "0.4.4",
+  "version": "0.4.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1180,15 +1180,16 @@
       }
     },
     "d3plus-axis": {
-      "version": "0.3.50",
-      "resolved": "https://registry.npmjs.org/d3plus-axis/-/d3plus-axis-0.3.50.tgz",
-      "integrity": "sha512-KGoxxQoK+UKZTFw1nhmFXuTyyorZ5/tHnTV65BtsbzW0D+3Xo1rbz4ogYuahuNspfDmhyGekddbAowv8zuOvyQ==",
+      "version": "0.3.52",
+      "resolved": "https://registry.npmjs.org/d3plus-axis/-/d3plus-axis-0.3.52.tgz",
+      "integrity": "sha512-ihrJmPXdae5gqi8ZPR5B6hXKJ0tOeOkk+NR5+3VhhEfjfA2EVmBa3toIutPGdhsRtvuFrnuBBqs/iO9T/pytIw==",
       "requires": {
         "d3-array": "^1.2.4",
         "d3-scale": "^2.1.2",
         "d3-selection": "^1.3.2",
         "d3-transition": "^1.1.3",
         "d3plus-common": "^0.6.43",
+        "d3plus-format": "^0.1.1",
         "d3plus-shape": "^0.16.0",
         "d3plus-text": "^0.9.33"
       }
@@ -1256,6 +1257,14 @@
         "tape-run": "^4.0.0",
         "uglify-js": "^3.1.2",
         "zora": "^2.0.0"
+      }
+    },
+    "d3plus-format": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/d3plus-format/-/d3plus-format-0.1.2.tgz",
+      "integrity": "sha512-R7NMAzpEfyLMQtUxK6TA+IuYmMMfg0jnbswLbS48hTRnPgrhl/nZe5PAisnrksucshmCEUwH9ETbJGNYY0rqcA==",
+      "requires": {
+        "d3-format": "^1.3.0"
       }
     },
     "d3plus-shape": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "d3-brush": "^1.0.6",
     "d3-selection": "^1.3.2",
-    "d3plus-axis": "^0.3.50",
+    "d3plus-axis": "^0.3.52",
     "d3plus-common": "^0.6.43"
   },
   "scripts": {

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -58,7 +58,6 @@ export default class Timeline extends Axis {
       y: d => this._buttonBehaviorCurrent === "buttons" ? this._align === "middle" ? this._height / 2 : this._align === "start" ? this._margin.top + this._buttonHeight / 2 : this._height - this._buttonHeight / 2 - this._margin.bottom : d.y
     });
     this._snapping = true;
-    this._tickSpecifier = undefined;
 
   }
 
@@ -467,16 +466,6 @@ function() {
   */
   snapping(_) {
     return arguments.length ? (this._snapping = _, this) : this._snapping;
-  }
-
-  /**
-      @memberof Timeline
-      @desc Allows to set ticks using custom specifiers.  If *value* is not specified, the default time format is returned.
-      @param {String} [*value* = undefined]
-      @chainable
-  */
-  tickSpecifier(_) {
-    return arguments.length ? (this._tickSpecifier = _, this) : this._tickSpecifier;
   }
 
 }

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -340,7 +340,8 @@ export default class Timeline extends Axis {
 
     this._outerBounds.y -= this._handleSize / 2;
     this._outerBounds.height += this._handleSize / 2;
-    console.log(this)
+    
+    return this;
   }
 
   /**

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -302,7 +302,7 @@ export default class Timeline extends Axis {
       ];
     }
 
-    if (this._ticks) this._domain = this._ticks.map(date);
+    if (this._ticks) this._domain = this._buttonBehavior === "ticks" ? [this._ticks[0], this._ticks[this._ticks.length - 1]] : this._ticks.map(date);
 
     this._labels = this._ticks;
 

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -58,6 +58,7 @@ export default class Timeline extends Axis {
       y: d => this._buttonBehaviorCurrent === "buttons" ? this._align === "middle" ? this._height / 2 : this._align === "start" ? this._margin.top + this._buttonHeight / 2 : this._height - this._buttonHeight / 2 - this._margin.bottom : d.y
     });
     this._snapping = true;
+    this._tickSpecifier = undefined;
 
   }
 
@@ -246,15 +247,15 @@ export default class Timeline extends Axis {
 
       let ticks = this._ticks ? this._ticks.map(date) : this._domain.map(date);
 
-      const d3Scale = scaleTime().domain(ticks).range([0, this._width]),
-            tickFormat = d3Scale.tickFormat();
+      const d3Scale = scaleTime().domain(ticks).range([0, this._width]);
 
       ticks = this._ticks ? ticks : d3Scale.ticks();
 
-      if (!this._tickFormat) this._tickFormat = tickFormat;
+      if (!this._tickFormat) this._tickFormat = d3Scale.tickFormat(ticks.length - 1, this._tickSpecifier);
 
       // Measures size of ticks
-      this._ticksWidth = ticks.reduce((sum, d, i) => {
+      let maxLabel = 0;
+      ticks.forEach((d, i) => {
         const f = this._shapeConfig.labelConfig.fontFamily(d, i),
               s = this._shapeConfig.labelConfig.fontSize(d, i);
 
@@ -263,24 +264,27 @@ export default class Timeline extends Axis {
           .fontSize(s)
           .lineHeight(this._shapeConfig.lineHeight ? this._shapeConfig.lineHeight(d, i) : undefined);
 
-        const res = wrap(tickFormat(d));
-
+        const res = wrap(d3Scale.tickFormat(ticks.length - 1, this._tickSpecifier)(d));
         let width = res.lines.length
           ? Math.ceil(max(res.lines.map(line => textWidth(line, {"font-family": f, "font-size": s})))) + s / 4
           : 0;
         if (width % 2) width++;
-        return sum + width + 2 * this._buttonPadding;
-      }, 0);
+        if (maxLabel < width) maxLabel = width + 2 * this._buttonPadding;
+      });
+
+      this._ticksWidth = maxLabel * ticks.length;
     }
 
     this._buttonBehaviorCurrent = this._buttonBehavior === "auto" ? this._ticksWidth < this._width ? "buttons" : "ticks" : this._buttonBehavior;
 
     if (this._buttonBehaviorCurrent === "buttons") {
       this._scale = "ordinal";
+      this._labelRotation = 0;
       if (!this._brushing) this._handleSize = 0;
       const domain = this._domain.map(date).map(this._tickFormat).map(Number);
 
       this._domain = this._ticks ? this._ticks.map(date) : Array.from(Array(domain[domain.length - 1] - domain[0] + 1), (_, x) => domain[0] + x).map(date);
+
       this._ticks = this._domain;
 
       const buttonMargin = 0.5 * this._ticksWidth / this._ticks.length;
@@ -297,11 +301,9 @@ export default class Timeline extends Axis {
         this._buttonAlign === "start" ? undefined : this._marginLeft + buttonMargin,
         this._buttonAlign === "end" ? undefined : marginRight - buttonMargin
       ];
-    } 
-
-    if (this._buttonBehaviorCurrent === "ticks" && this._ticks) {
-      this._domain = [this._ticks[0], this._ticks[this._ticks.length - 1]];
     }
+
+    if (this._ticks) this._domain = this._ticks.map(date);
 
     this._labels = this._ticks;
 
@@ -332,17 +334,13 @@ export default class Timeline extends Axis {
 
     this._updateBrushLimit(selection);
 
-    elem("g.ticks", {parent: this._group}).attr("class", this._buttonBehaviorCurrent);
-
     this._brushGroup = elem("g.brushGroup", {parent: this._group});
     this._brushGroup.call(brush).transition(this._transition)
       .call(brush.move, this._buttonBehaviorCurrent === "ticks" ? this._updateBrushLimit(selection) : selection);
 
     this._outerBounds.y -= this._handleSize / 2;
     this._outerBounds.height += this._handleSize / 2;
-
-    return this;
-
+    console.log(this)
   }
 
   /**
@@ -468,6 +466,16 @@ function() {
   */
   snapping(_) {
     return arguments.length ? (this._snapping = _, this) : this._snapping;
+  }
+
+  /**
+      @memberof Timeline
+      @desc Allows to set ticks using custom specifiers.  If *value* is not specified, the default time format is returned.
+      @param {String} [*value* = undefined]
+      @chainable
+  */
+  tickSpecifier(_) {
+    return arguments.length ? (this._tickSpecifier = _, this) : this._tickSpecifier;
   }
 
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
closes #47 

### Description
<!--- Describe your changes in detail -->
This PR fixes the problem of weird render of labels adding a new feature called `tickSpecifier`, that allows customize the tick format. 

This new method uses tickFormat from d3-scale ([https://github.com/d3/d3-scale#time_tickFormat](https://github.com/d3/d3-scale#time_tickFormat)) and also it fixes minor bugs detected, like weird width of timeline with ticks when domain is not defined.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

