### PR TITLE
Bug/timeline icon

### DIFF
--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -109,7 +109,7 @@ export default class Timeline extends Axis {
     this._playButtonConfig = {
       fontColor: colorDefaults.dark,
       fontSize: 15,
-      text: () => this._playTimer ? "⏸" : "⏵",
+      text: () => this._playTimer ? "◼" : "▶",
       textAnchor: "middle",
       verticalAlign: "middle"
     };
@@ -512,7 +512,7 @@ export default class Timeline extends Axis {
         height: playButtonWidth
       }] : [])
       .select(playButtonGroup.node())
-      .config(this._playButtonConfig)
+      .config(assign(this._playButtonConfig, {text: this._playButtonConfig.text.bind(this)}))
       .render();
 
     return this;

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -109,7 +109,7 @@ export default class Timeline extends Axis {
     this._playButtonConfig = {
       fontColor: colorDefaults.dark,
       fontSize: 15,
-      text: () => this._playTimer ? "◼" : "▶",
+      text: () => this._playTimer ? "⏸" : "⏵",
       textAnchor: "middle",
       verticalAlign: "middle"
     };


### PR DESCRIPTION
We found that the play/pause button icons were not working properly on Android devices. We tried to modify them, and we fixed it for Android, but stopped working on iPhone (replaced by emoji).

When trying to override it, we found that the `_timerPlay` boolean was not externally accessible, so we modified the `playButtonConfig` to bind the text function.

Seba will try to fix the problem for the different OS, but for now he needs this change to override it in DataSaudi.